### PR TITLE
added finites, which generates all elements of Finite n

### DIFF
--- a/src/Data/Finite.hs
+++ b/src/Data/Finite.hs
@@ -13,7 +13,7 @@ module Data.Finite
         Finite,
         packFinite, packFiniteProxy,
         finite, finiteProxy,
-        getFinite,
+        getFinite, finites, finitesProxy,
         equals, cmp,
         natToFinite,
         weaken, strengthen, shift, unshift,
@@ -28,6 +28,7 @@ module Data.Finite
 
 import Data.Maybe
 import GHC.TypeLits
+import Data.Proxy
 
 import Data.Finite.Internal
 
@@ -46,6 +47,14 @@ packFiniteProxy _ = packFinite
 -- | Same as 'finite' but with a proxy argument to avoid type signatures.
 finiteProxy :: KnownNat n => proxy n -> Integer -> Finite n
 finiteProxy _ = finite
+
+-- | Generate a list of length @n@ of all elements of @'Finite' n@.
+finites :: KnownNat n => [Finite n]
+finites = finitesProxy Proxy
+
+-- | Same as 'finites' but with a proxy argument to avoid type signatures.
+finitesProxy :: KnownNat n => Proxy n -> [Finite n]
+finitesProxy p = Finite <$> [0 .. (natVal p - 1)]
 
 -- | Test two different types of finite numbers for equality.
 equals :: Finite n -> Finite m -> Bool

--- a/src/Data/Finite.hs
+++ b/src/Data/Finite.hs
@@ -28,7 +28,6 @@ module Data.Finite
 
 import Data.Maybe
 import GHC.TypeLits
-import Data.Proxy
 
 import Data.Finite.Internal
 
@@ -50,11 +49,13 @@ finiteProxy _ = finite
 
 -- | Generate a list of length @n@ of all elements of @'Finite' n@.
 finites :: KnownNat n => [Finite n]
-finites = finitesProxy Proxy
+finites = results
+  where
+    results = Finite <$> [0 .. (natVal (head results) - 1)]
 
 -- | Same as 'finites' but with a proxy argument to avoid type signatures.
-finitesProxy :: KnownNat n => Proxy n -> [Finite n]
-finitesProxy p = Finite <$> [0 .. (natVal p - 1)]
+finitesProxy :: KnownNat n => proxy n -> [Finite n]
+finitesProxy _ = finites
 
 -- | Test two different types of finite numbers for equality.
 equals :: Finite n -> Finite m -> Bool


### PR DESCRIPTION
Just a utility function that I have found useful a few times!  Feel free to reject, I've been doing fine with this just as a local utility function :)

~~~haskell
finites :: KnownNat n => [Finite n]
finitesProxy :: KnownNat n => Proxy n -> [Finite n]

> finites :: [Finite 5]
[finite 0, finite 1, finite 2, finite 3, finite 4]
~~~

Useful as the generator for ghc listy stream fusion stuff as well.