### PR TITLE
modClass :: Integer -> Finite n

### DIFF
--- a/src/Data/Finite.hs
+++ b/src/Data/Finite.hs
@@ -16,6 +16,7 @@ module Data.Finite
         getFinite, finites, finitesProxy,
         equals, cmp,
         natToFinite,
+        modClass,
         weaken, strengthen, shift, unshift,
         weakenN, strengthenN, shiftN, unshiftN,
         weakenProxy, strengthenProxy, shiftProxy, unshiftProxy,

--- a/src/Data/Finite.hs
+++ b/src/Data/Finite.hs
@@ -181,11 +181,11 @@ separateProduct (Finite x) = result
 isValidFinite :: KnownNat n => Finite n -> Bool
 isValidFinite fx@(Finite x) = x < natVal fx && x >= 0
 
--- | Interpret an 'Integer' as a member of a congruency class of @(`mod`
+-- | Interpret an 'Integral' as a member of a congruency class of @(`mod`
 -- n)@
 --
--- Essentially 'fromInteger' precomposed with 'mod'.
-modClass :: KnownNat n => Integer -> Finite n
+-- Essentially 'fromIntegral' precomposed with 'mod'.
+modClass :: (Integral a, KnownNat n) => a -> Finite n
 modClass x = result
   where
-    result = Finite (x `mod` natVal result)
+    result = Finite (fromIntegral x `mod` natVal result)

--- a/src/Data/Finite.hs
+++ b/src/Data/Finite.hs
@@ -179,3 +179,12 @@ separateProduct (Finite x) = result
 -- | Verifies that a given 'Finite' is valid. Should always return 'True' unles you bring the @Data.Finite.Internal.Finite@ constructor into the scope, or use 'Unsafe.Coerce.unsafeCoerce' or other nasty hacks
 isValidFinite :: KnownNat n => Finite n -> Bool
 isValidFinite fx@(Finite x) = x < natVal fx && x >= 0
+
+-- | Interpret an 'Integer' as a member of a congruency class of @(`mod`
+-- n)@
+--
+-- Essentially 'fromInteger' precomposed with 'mod'.
+modClass :: KnownNat n => Integer -> Finite n
+modClass x = result
+  where
+    result = Finite (x `mod` natVal result)


### PR DESCRIPTION
`fromInteger`, except pre-composes with `mod` to wrap around numbers that are out of range.  Essentially interprets an integer as a member of a congruency class defined by mod n.

Useful with *vector-sized*, manipulating indices with periodic boundary conditions.