### PR TITLE
add 'withFinite' to pass a 'Finite' at the type level

### DIFF
--- a/finite-typelits.cabal
+++ b/finite-typelits.cabal
@@ -13,6 +13,7 @@ cabal-version:       >=1.10
 
 library
   exposed-modules:     Data.Finite, Data.Finite.Internal
+  other-modules:       Data.Finite.Internal.With
   build-depends:       base >= 4.7
                      , deepseq >= 1.4
   hs-source-dirs:      src

--- a/src/Data/Finite.hs
+++ b/src/Data/Finite.hs
@@ -14,6 +14,7 @@ module Data.Finite
         packFinite, packFiniteProxy,
         finite, finiteProxy,
         getFinite, finites, finitesProxy,
+        withFinite,
         modulo, moduloProxy,
         equals, cmp,
         natToFinite,
@@ -31,6 +32,7 @@ import Data.Maybe
 import GHC.TypeLits
 
 import Data.Finite.Internal
+import Data.Finite.Internal.With
 
 -- | Convert an 'Integer' into a 'Finite', returning 'Nothing' if the input is out of bounds.
 packFinite :: KnownNat n => Integer -> Maybe (Finite n)

--- a/src/Data/Finite.hs
+++ b/src/Data/Finite.hs
@@ -28,6 +28,7 @@ module Data.Finite
     )
     where
 
+import Data.Coerce
 import Data.Maybe
 import GHC.TypeLits
 
@@ -54,7 +55,7 @@ finiteProxy _ = finite
 finites :: KnownNat n => [Finite n]
 finites = results
   where
-    results = Finite `fmap` [0 .. (natVal (head results) - 1)]
+    results = coerce [0 .. (natVal (head results) - 1)]
 
 -- | Same as 'finites' but with a proxy argument to avoid type signatures.
 finitesProxy :: KnownNat n => proxy n -> [Finite n]

--- a/src/Data/Finite/Internal/With.hs
+++ b/src/Data/Finite/Internal/With.hs
@@ -1,0 +1,28 @@
+
+{-# LANGUAGE TypeOperators, DataKinds, TypeFamilies, FlexibleContexts,
+  AllowAmbiguousTypes, RankNTypes, ScopedTypeVariables, TypeApplications #-}
+
+module Data.Finite.Internal.With
+    (
+        withFinite
+    )
+    where
+
+import Data.Kind
+import Data.Proxy
+import Data.Type.Equality
+import GHC.TypeNats
+import Unsafe.Coerce
+
+import Data.Finite.Internal
+
+-- | Pass a 'Finite' to a function expecting a type-level natural (passed via a 'Proxy').
+withFinite
+  :: forall (n :: Nat) (r :: Type)
+  .  ( forall i. ( KnownNat i, CmpNat i n ~ 'LT ) => Proxy i -> r )
+  -> Finite n
+  -> r
+withFinite f j = case someNatVal ( fromIntegral $ getFinite j ) of
+  ( SomeNat ( px :: Proxy j ) ) ->
+    case unsafeCoerce Refl :: CmpNat j n :~: 'LT of
+      Refl -> f px


### PR DESCRIPTION
Adds the ability to pass a `Finite n`  as a type-level natural, packaged with a proof that it is less than `n`.

I've added the function to a separate internal module, as I'm using `unsafeCoerce` to create that proof, and wanted that to be contained to a separate module.