### PR TITLE
Add `difference`

### DIFF
--- a/src/Data/Finite.hs
+++ b/src/Data/Finite.hs
@@ -20,7 +20,7 @@ module Data.Finite
         weaken, strengthen, shift, unshift,
         weakenN, strengthenN, shiftN, unshiftN,
         weakenProxy, strengthenProxy, shiftProxy, unshiftProxy,
-        add, sub, multiply,
+        add, sub, difference, multiply,
         combineSum, combineProduct,
         separateSum, separateProduct,
         isValidFinite
@@ -158,6 +158,10 @@ sub :: Finite n -> Finite m -> Either (Finite m) (Finite n)
 sub (Finite x) (Finite y) = if x >= y
     then Right $ Finite $ x - y
     else Left $ Finite $ y - x
+
+-- | Difference between two 'Finite's
+difference :: Finite n -> Finite n -> Finite (n-1)
+difference (Finite x) (Finite y) = Finite (abs (x-y))
 
 -- | Multiply two 'Finite's.
 multiply :: Finite n -> Finite m -> Finite (n GHC.TypeLits.* m)


### PR DESCRIPTION
The type signature could be relaxed to
```haskell
difference :: Finite m -> Finite n -> Finite (Max m n - 1)
```
but afaict there's no way to do `Max` easily enough to be worth it