### PR TITLE
cabal: bump base upper bound (support GHC 9.6)

### DIFF
--- a/finite-typelits.cabal
+++ b/finite-typelits.cabal
@@ -14,7 +14,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:     Data.Finite
                      , Data.Finite.Internal
-  build-depends:       base >= 4.7 && < 4.18
+  build-depends:       base >= 4.7 && < 4.19
                      , deepseq >= 1.4
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -24,7 +24,7 @@ test-Suite finite-typelits-tests
   type:                exitcode-stdio-1.0
   main-is:             test/Main.hs
   build-depends:       finite-typelits
-                     , base >= 4.9 && < 4.18
+                     , base >= 4.9 && < 4.19
                      , deepseq >= 1.4
                      , QuickCheck
   default-language:    Haskell2010


### PR DESCRIPTION
No code changes needed as far as I can see (tests pass).

This change could be applied as a revision on Hackage to support GHC 9.6 without much effort.