### PR TITLE
Support `QuickCheck` versions `>= 2.17.0.0`.

### DIFF
--- a/finite-typelits.cabal
+++ b/finite-typelits.cabal
@@ -30,5 +30,5 @@ test-suite finite-typelits-tests
   build-depends:       finite-typelits
                      , base >= 4.9 && < 4.22
                      , deepseq >= 1.4 && < 1.6
-                     , QuickCheck >= 2.12 && < 2.16
+                     , QuickCheck >= 2.12 && < 2.18
   default-language:    Haskell2010

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -45,8 +46,10 @@ instance (Integral a, Arbitrary a) => Arbitrary (SmallNonNeg a) where
     arbitrary = SmallNonNeg <$> arbitrarySizedNatural
     shrink (SmallNonNeg x) = SmallNonNeg <$> shrink x
 
+#if !MIN_VERSION_QuickCheck(2,17,0)
 instance Arbitrary Natural where
     arbitrary = fromInteger . getNonNegative <$> arbitrary
+#endif
 
 instance CoArbitrary Natural where
     coarbitrary n = coarbitrary (toInteger n)


### PR DESCRIPTION
This PR adds support for building with `QuickCheck` versions `>= 2.17.0.0 && < 2.18`.

Version `2.17.0.0` of the `QuickCheck` library added an `Arbitrary` instance for `Natural` (but did not add an instance for `CoArbitrary`).

The new instance conflicts with the test instance defined in this package. To solve this conflict, this PR selectively disables compilation of the test instance for `QuickCheck` versions `>= 2.17.0.0`.