### PR TITLE
Support `QuickCheck` `2.18` series.

### DIFF
--- a/finite-typelits.cabal
+++ b/finite-typelits.cabal
@@ -30,5 +30,5 @@ test-suite finite-typelits-tests
   build-depends:       finite-typelits
                      , base >= 4.9 && < 4.23
                      , deepseq >= 1.4 && < 1.6
-                     , QuickCheck >= 2.12 && < 2.18
+                     , QuickCheck >= 2.12 && < 2.19
   default-language:    Haskell2010

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -51,8 +51,10 @@ instance Arbitrary Natural where
     arbitrary = fromInteger . getNonNegative <$> arbitrary
 #endif
 
+#if !MIN_VERSION_QuickCheck(2,18,0)
 instance CoArbitrary Natural where
     coarbitrary n = coarbitrary (toInteger n)
+#endif
 
 newtype Small a n = Small (Finite a n)
     deriving (Show)


### PR DESCRIPTION
Since `QuickCheck` version `2.18.0.0` exports its own `CoArbitrary` instance for `Natural`, we use conditional compilation to avoid a conflict with the instance defined in the test suite.

Tested with all of the following versions:

```
cabal test all --enable-tests --constraint=QuickCheck==2.16.0.0
cabal test all --enable-tests --constraint=QuickCheck==2.17.0.0
cabal test all --enable-tests --constraint=QuickCheck==2.17.1.0
cabal test all --enable-tests --constraint=QuickCheck==2.18.0.0
```